### PR TITLE
Fixed syntax errors.

### DIFF
--- a/njhigham_bibbase.bib
+++ b/njhigham_bibbase.bib
@@ -1,9 +1,9 @@
-This file is for use by Bibbase only.
-The field `howpublished' has been replaced by a `url' field.
+@Comment This file is for use by Bibbase only.
+@Comment The field `howpublished' has been replaced by a `url' field.
 
-,-------------------.
-|  BIBTEX ENTRIES   |
-`-------------------'
+@Comment ,-------------------.
+@Comment |  BIBTEX ENTRIES   |
+@Comment `-------------------'
 
 @article{alhi09,
   author =        {Awad H. Al-Mohy and Nicholas J. Higham},


### PR DESCRIPTION
Nick, you had comments in this bibtex file that were not marked as such (but were just plain text). The old bibtex parser may have been fine with that (although it may not have and simply may have served a cached version for a while --  I don't know). But the new bibtex parser we are using cannot handle this. Our goal is to make the new parser more robust against such syntax error -- similar to how the other syntax errors that remain in this file are being handled and reported (you'l see). But for now I suggest using strict bibtex syntax and marking the comments as suggested in this edit.
